### PR TITLE
C code for Welch's t test

### DIFF
--- a/R/welch_t_test.R
+++ b/R/welch_t_test.R
@@ -28,27 +28,8 @@ welch_t_test <- function (vals, grps, arms = unique(grps), na_replacement = NULL
 	x <- vals[grps == arms[2]]
 	y <- vals[grps == arms[1]]
 
-	nx <- length(x)
-	mx <- fast_mean(x)
-	stderrx <- sqrt(stats::var(x) / nx)
-
-	ny <- length(y)
-	my <- fast_mean(y)
-	stderry <- sqrt(stats::var(y) / ny)
-
-	stderr <- sqrt(stderrx^2 + stderry^2)
-
-	df <- stderr^4 / (stderrx^4 / (nx - 1) + stderry^4 / (ny - 1))
-	t_stat <- (mx - my) / stderr
-	p_value <- 2 * stats::pt(-abs(t_stat), df)
-	conf_int <- stderr * (t_stat + c(-1, 1) * stats::qt(1 - alpha * 0.5, df))
-
-	list(
-		comparator = arms[1],
-		target = arms[2],
-		est = mx - my,
-		p_value = p_value,
-		ci_lo = conf_int[1],
-		ci_hi = conf_int[2]
+	setNames(
+		c(as.list(arms), .Call(C_welch_t_test, x, y, alpha)),
+		c("comparator", "target", "est", "p_value", "ci_lo", "ci_hi")
 	)
 }

--- a/src/bootstrap_mean_diffs.c
+++ b/src/bootstrap_mean_diffs.c
@@ -14,8 +14,8 @@ SEXP bootstrap_mean_diffs(SEXP vals, SEXP grps, SEXP B)
 	pgrps = INTEGER(grps);
 
 	SEXP boot_estimates = PROTECT(allocVector(REALSXP, asInteger(B)));
-	double *pboot_estimates;
-	pboot_estimates = REAL(boot_estimates);
+	double *_boot_estimates;
+	_boot_estimates = REAL(boot_estimates);
 
 	double sums[2] = {0.0, 0.0}; // summed values in actv and ctrl, resp.
 	int ns[2] = {0, 0}; // no. of values in actv and ctrl, resp.
@@ -33,11 +33,12 @@ SEXP bootstrap_mean_diffs(SEXP vals, SEXP grps, SEXP B)
 			ns[pgrps[idx]] += 1;
 		}
 
-		pboot_estimates[b] = sums[0]/ns[0] - sums[1]/ns[1];
+		_boot_estimates[b] = sums[0]/ns[0] - sums[1]/ns[1];
 	}
 
-	UNPROTECT(1);
 	PutRNGstate(); // write out .Random.seed
+
+	UNPROTECT(1);
 
 	return boot_estimates;
 }

--- a/src/hrqolr.h
+++ b/src/hrqolr.h
@@ -9,5 +9,6 @@ SEXP auc(SEXP x, SEXP y);
 SEXP bootstrap_mean_diffs(SEXP vals, SEXP grps, SEXP B);
 SEXP create_xout(SEXP start, SEXP end, SEXP by);
 SEXP mean(SEXP x);
+SEXP welch_t_test(SEXP x, SEXP y, SEXP alpha);
 
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -11,6 +11,7 @@ static const R_CallMethodDef callEntries[] = {
 	{"bootstrap_mean_diffs", (DL_FUNC) &bootstrap_mean_diffs, 3},
 	{"create_xout", (DL_FUNC) &create_xout, 3},
 	{"mean", (DL_FUNC) &mean, 1},
+	{"welch_t_test", (DL_FUNC) &welch_t_test, 3},
 	{NULL, NULL, 0}
 };
 

--- a/src/welch_t_test.c
+++ b/src/welch_t_test.c
@@ -1,0 +1,71 @@
+#include <R.h>
+#include <Rinternals.h>
+#include <Rmath.h>
+#include "hrqolr.h"
+
+// Variance estimates using shifted data (to obtain single-pass logic), see:
+// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+
+SEXP welch_t_test(SEXP x, SEXP y, SEXP alpha)
+{
+	double _alpha = asReal(alpha);
+
+	size_t nx = length(x);
+	double *px;
+	px = REAL(x);
+
+	size_t ny = length(y);
+	double *py;
+	py = REAL(y);
+
+	// Summary stats of x
+	double mux = 0.0; // mean of x
+	double Ex = 0.0; // expected value of x
+	double Ex2 = 0.0; // expected value of x^2
+	double Kx = px[0]; // constant, must be within range of x
+
+	for (int i = 0; i < nx; i++) {
+		mux += px[i] / nx;
+		Ex += px[i] - Kx;
+		Ex2 += pow(px[i] - Kx, 2);
+	}
+	double sex = sqrt((Ex2 - pow(Ex, 2)/nx) / (nx - 1) / nx); // std. error of x
+
+	// Summary stats of y (logic identical that of x above)
+	double muy = 0.0;
+	double Ey = 0.0;
+	double Ey2 = 0.0;
+	double Ky = py[0];
+
+	for (int i = 0; i < ny; i++) {
+		muy += py[i] / ny;
+		Ey += py[i] - Ky;
+		Ey2 += pow(py[i] - Ky, 2);
+	}
+	double sey = sqrt((Ey2 - pow(Ey, 2)/ny) / (ny - 1) / ny);
+
+	// Carry out actual null-hypothesis test
+	double se = sqrt(pow(sex, 2) + pow(sey, 2));
+	double degs_free = pow(se, 4) / (pow(sex, 4) / (nx - 1) + pow(sey, 4) / (ny - 1));
+	double t_stat = (mux - muy) / se;
+
+	double p_value = 2 * pt(-fabs(t_stat), degs_free, 1, 0);
+
+	double conf_int[2];
+	double q = qt(1.0 - _alpha * 0.5, degs_free, 1, 0);
+	conf_int[0] = se * (t_stat - q);
+	conf_int[1] = se * (t_stat + q);
+
+	SEXP out = PROTECT(allocVector(REALSXP, 4));
+	double *_out;
+	_out = REAL(out);
+
+	_out[0] = mux - muy;
+	_out[1] = p_value;
+	_out[2] = conf_int[0];
+	_out[3] = conf_int[1];
+
+	UNPROTECT(1);
+
+	return out;
+}

--- a/tests/testthat/test-c_functions.R
+++ b/tests/testthat/test-c_functions.R
@@ -35,3 +35,14 @@ test_that("C_bootstrap_mean_diffs works", {
 	)
 })
 
+test_that("C_welch_t_test works", {
+	x <- as.double(1:10)
+	y <- as.double(6:15)
+	alpha <- 0.05
+	welch_hrqolr <- .Call(C_welch_t_test, x, y, alpha)
+	welch_stats <- with(
+		stats::t.test(x, y, var.equal = FALSE, conf.level = 1 - alpha),
+		as.numeric(c(est = mean(x) - mean(y), p.value, conf.int)) # t.test doesn't return point estimate
+	)
+	expect_equal(welch_hrqolr, welch_stats)
+})


### PR DESCRIPTION
The core of Welch's t test is now written in C ([here](https://github.com/INCEPTdk/hrqolr/blob/dev/src/welch_t_test.c)). The core logic is about 10x faster than equivalent in R, but due to overhead in handling missing values, the current `welch_t_test()` is only some 3x faster than before. Still a significant boost, and faster handling of missing values should follow at a later stage.